### PR TITLE
Feat/thread kv store

### DIFF
--- a/app/nats-kv.go
+++ b/app/nats-kv.go
@@ -22,6 +22,8 @@ func NewKvThreadStore(bucket string, domain string, opts []nats.Option) (ThreadS
 	var err error
 	ts := &kvThreadStore{}
 
+	//This is a bit awkward since there isnt any context, or nats-connection object, in the
+	//bootstrapping of the app.
 	ts.ctx = context.Background()
 
 	url := os.Getenv("NATS_URL")
@@ -59,7 +61,7 @@ func (ts *kvThreadStore) GetThread(threadID string) (*thread.Thread, error) {
 	if err != nil {
 		return nil, err
 	}
-	t := thread.Thread{}
+	var t thread.Thread
 	if err = json.Unmarshal(v.Value(), &t); err != nil {
 		return nil, err
 	}

--- a/app/nats-kv.go
+++ b/app/nats-kv.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"os"
+	"time"
 
 	"github.com/henomis/lingoose/thread"
 	"github.com/nats-io/nats.go"
@@ -51,7 +52,10 @@ func NewKvThreadStore(bucket string, domain string, opts []nats.Option) (ThreadS
 }
 
 func (ts *kvThreadStore) GetThread(threadID string) (*thread.Thread, error) {
-	v, err := ts.kv.Get(ts.ctx, threadID)
+	ctx, cancel := context.WithTimeout(ts.ctx, time.Second*5)
+	defer cancel()
+
+	v, err := ts.kv.Get(ctx, threadID)
 	if err != nil {
 		return nil, err
 	}
@@ -63,11 +67,14 @@ func (ts *kvThreadStore) GetThread(threadID string) (*thread.Thread, error) {
 }
 
 func (ts *kvThreadStore) StoreThread(threadID string, thread *thread.Thread) error {
+	ctx, cancel := context.WithTimeout(ts.ctx, time.Second*5)
+	defer cancel()
+
 	j, err := json.Marshal(thread)
 	if err != nil {
 		return err
 	}
-	if _, err := ts.kv.Put(ts.ctx, threadID, j); err != nil {
+	if _, err := ts.kv.Put(ctx, threadID, j); err != nil {
 		return err
 	}
 	return nil

--- a/app/nats-kv.go
+++ b/app/nats-kv.go
@@ -1,0 +1,74 @@
+package app
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+
+	"github.com/henomis/lingoose/thread"
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+type kvThreadStore struct {
+	nc  *nats.Conn
+	js  jetstream.JetStream
+	kv  jetstream.KeyValue
+	ctx context.Context
+}
+
+func NewKvThreadStore(bucket string, domain string, opts []nats.Option) (ThreadStore, error) {
+	var err error
+	ts := &kvThreadStore{}
+
+	ts.ctx = context.Background()
+
+	url := os.Getenv("NATS_URL")
+	if url == "" {
+		url = nats.DefaultURL
+	}
+
+	ts.nc, err = nats.Connect(url, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	if domain != "" {
+		ts.js, err = jetstream.NewWithDomain(ts.nc, domain)
+	} else {
+		ts.js, err = jetstream.New(ts.nc)
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	ts.kv, err = ts.js.KeyValue(ts.ctx, bucket)
+	if err != nil {
+		return nil, err
+	}
+	return ts, nil
+}
+
+func (ts *kvThreadStore) GetThread(threadID string) (*thread.Thread, error) {
+	v, err := ts.kv.Get(ts.ctx, threadID)
+	if err != nil {
+		return nil, err
+	}
+	t := thread.Thread{}
+	if err = json.Unmarshal(v.Value(), &t); err != nil {
+		return nil, err
+	}
+	return &t, nil
+}
+
+func (ts *kvThreadStore) StoreThread(threadID string, thread *thread.Thread) error {
+	j, err := json.Marshal(thread)
+	if err != nil {
+		return err
+	}
+	if _, err := ts.kv.Put(ts.ctx, threadID, j); err != nil {
+		return err
+	}
+	return nil
+}

--- a/app/options.go
+++ b/app/options.go
@@ -1,115 +1,136 @@
 package app
 
 import (
-  "github.com/nats-io/nats.go"
-  "github.com/spf13/cobra"
-  "github.com/spf13/viper"
-  "time"
+	"time"
+
+	"github.com/nats-io/nats.go"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 type Option func(*Options)
 
 func ViperFlags(cmd *cobra.Command) {
-  cmd.PersistentFlags().StringP("server", "s", "nats://localhost:4222", "Nats Server Url")
-  cmd.PersistentFlags().String("creds", "", "Nats User Credentials")
-  cmd.PersistentFlags().String("user", "", "Nats Username or Token")
-  cmd.PersistentFlags().String("password", "", "Nats Password")
-  cmd.PersistentFlags().String("nkey", "", "Nats User NKEY")
+	cmd.PersistentFlags().StringP("server", "s", "nats://localhost:4222", "Nats Server Url")
+	cmd.PersistentFlags().String("creds", "", "Nats User Credentials")
+	cmd.PersistentFlags().String("user", "", "Nats Username or Token")
+	cmd.PersistentFlags().String("password", "", "Nats Password")
+	cmd.PersistentFlags().String("nkey", "", "Nats User NKEY")
 
-  cmd.PersistentFlags().String("ollama-url", "http://localhost:11434/api", "the endpoint to the ollama service")
-  cmd.PersistentFlags().String("ollama-default-model", "llama3:latest", "the default model to use if none is provided")
-  cmd.PersistentFlags().StringP("ttl", "t", "10m", "the amount of time to keep a thread in memory")
-  cmd.PersistentFlags().IntP("count", "c", 10, "the number of threads to keep in memory")
+	cmd.PersistentFlags().String("ollama-url", "http://localhost:11434/api", "the endpoint to the ollama service")
+	cmd.PersistentFlags().String("ollama-default-model", "llama3:latest", "the default model to use if none is provided")
+	cmd.PersistentFlags().StringP("ttl", "t", "10m", "the amount of time to keep a thread in memory")
+	cmd.PersistentFlags().IntP("count", "c", 10, "the number of threads to keep in memory")
+	cmd.PersistentFlags().String("bucket", "", "kv bucket to store threads in")
+	cmd.PersistentFlags().String("jsdomain", "", "kv bucket is located in js domain")
 
-  cmd.PersistentFlags().StringP("loglevel", "l", "INFO", "the log level")
+	cmd.PersistentFlags().StringP("loglevel", "l", "INFO", "the log level")
 }
 
 func FromViper(v *viper.Viper) []Option {
-  var result []Option
+	var result []Option
 
-  result = append(result, WithNatsUrl(v.GetString("server")))
-  result = append(result, WithOllamaUrl(v.GetString("ollama-url")))
-  result = append(result, WithMemoryThreadStore(v.GetString("ttl"), v.GetInt("count")))
-  result = append(result, WithLogLevel(v.GetString("loglevel")))
-  result = append(result, WithDefaultModel(v.GetString("ollama-default-model")))
+	result = append(result, WithNatsUrl(v.GetString("server")))
+	result = append(result, WithOllamaUrl(v.GetString("ollama-url")))
+	result = append(result, WithLogLevel(v.GetString("loglevel")))
+	result = append(result, WithDefaultModel(v.GetString("ollama-default-model")))
 
-  // -- required
-  user := v.GetString("user")
-  password := v.GetString("password")
-  nkey := v.GetString("nkey")
-  credsFile := v.GetString("creds")
+	// -- required
+	user := v.GetString("user")
+	password := v.GetString("password")
+	nkey := v.GetString("nkey")
+	credsFile := v.GetString("creds")
 
-  if credsFile != "" {
-    result = append(result, WithCredentialsFile(credsFile))
-  } else if user != "" && nkey != "" {
-    result = append(result, WithCredentials(user, nkey))
-  } else if user != "" && password != "" {
-    result = append(result, WithUsernamePassword(user, password))
-  }
+	if credsFile != "" {
+		result = append(result, WithCredentialsFile(credsFile))
+	} else if user != "" && nkey != "" {
+		result = append(result, WithCredentials(user, nkey))
+	} else if user != "" && password != "" {
+		result = append(result, WithUsernamePassword(user, password))
+	}
 
-  return result
+	bucket := v.GetString("bucket")
+	if bucket != "" {
+		result = append(result, WithKVThreadStore(bucket, v.GetString("jsdomain")))
+	} else {
+		result = append(result, WithMemoryThreadStore(v.GetString("ttl"), v.GetInt("count")))
+	}
+
+	return result
 }
 
 type Options struct {
-  NatsUrl      string
-  NatsOptions  []nats.Option
-  OllamaUrl    string
-  LogLevel     string
-  ThreadStore  ThreadStore
-  DefaultModel string
+	NatsUrl      string
+	NatsOptions  []nats.Option
+	OllamaUrl    string
+	LogLevel     string
+	ThreadStore  ThreadStore
+	DefaultModel string
+	JsDomain     string
+	Bucket       string
 }
 
 func WithNatsUrl(url string) Option {
-  return func(o *Options) {
-    o.NatsUrl = url
-  }
+	return func(o *Options) {
+		o.NatsUrl = url
+	}
 }
 
 func WithUsernamePassword(username string, password string) Option {
-  return func(o *Options) {
-    o.NatsOptions = append(o.NatsOptions, nats.UserInfo(username, password))
-  }
+	return func(o *Options) {
+		o.NatsOptions = append(o.NatsOptions, nats.UserInfo(username, password))
+	}
 }
 
 func WithCredentials(jwt string, seed string) Option {
-  return func(o *Options) {
-    o.NatsOptions = append(o.NatsOptions, nats.UserJWTAndSeed(jwt, seed))
-  }
+	return func(o *Options) {
+		o.NatsOptions = append(o.NatsOptions, nats.UserJWTAndSeed(jwt, seed))
+	}
 }
 
 func WithCredentialsFile(file string) Option {
-  return func(o *Options) {
-    o.NatsOptions = append(o.NatsOptions, nats.UserCredentials(file))
-  }
+	return func(o *Options) {
+		o.NatsOptions = append(o.NatsOptions, nats.UserCredentials(file))
+	}
 }
 
 func WithNatsOptions(opts ...nats.Option) Option {
-  return func(o *Options) {
-    o.NatsOptions = opts
-  }
+	return func(o *Options) {
+		o.NatsOptions = opts
+	}
 }
 
 func WithOllamaUrl(url string) Option {
-  return func(o *Options) {
-    o.OllamaUrl = url
-  }
+	return func(o *Options) {
+		o.OllamaUrl = url
+	}
 }
 
 func WithMemoryThreadStore(ttl string, count int) Option {
-  return func(o *Options) {
-    d, _ := time.ParseDuration(ttl)
-    o.ThreadStore = NewMemoryThreadStore(count, d)
-  }
+	return func(o *Options) {
+		d, _ := time.ParseDuration(ttl)
+		o.ThreadStore = NewMemoryThreadStore(count, d)
+	}
+}
+
+func WithKVThreadStore(bucket string, domain string) Option {
+	return func(o *Options) {
+		var err error
+		o.ThreadStore, err = NewKvThreadStore(bucket, domain, o.NatsOptions)
+		if err != nil {
+			panic(err)
+		}
+	}
 }
 
 func WithLogLevel(level string) Option {
-  return func(o *Options) {
-    o.LogLevel = level
-  }
+	return func(o *Options) {
+		o.LogLevel = level
+	}
 }
 
 func WithDefaultModel(model string) Option {
-  return func(o *Options) {
-    o.DefaultModel = model
-  }
+	return func(o *Options) {
+		o.DefaultModel = model
+	}
 }


### PR DESCRIPTION
Basic implementation of using NATS KV store for threads. 

This PR doesn't take into account the default max size of 1MB for messages, but i guess it wouldn't be that hard to migrate this to an object store instead. Since the messages in the thread is an array one could also use kv subjects prepended with the tread-id and suffixed with the array index or something. 

Encountered some slight issues tho that i didn't change, but created an issue for instead:
https://github.com/shono-io/nats-ai/issues/1

I haven't tested it in depth, but it seems to work fine. 